### PR TITLE
Support noble only

### DIFF
--- a/jammy/debian/changelog
+++ b/jammy/debian/changelog
@@ -1,6 +1,0 @@
-sdformat16 (15.999.999-1~jammy) jammy; urgency=medium
-
-  * Stub to be removed after first entry
-
- -- Carlos Aguero <caguero@openrobotics.org>  Tue, 08 Oct 2024 21:02:41 +0200
-

--- a/jammy/debian/compat
+++ b/jammy/debian/compat
@@ -1,1 +1,0 @@
-../../ubuntu/debian/compat

--- a/jammy/debian/control
+++ b/jammy/debian/control
@@ -1,1 +1,0 @@
-../../ubuntu/debian/control

--- a/jammy/debian/copyright
+++ b/jammy/debian/copyright
@@ -1,1 +1,0 @@
-../../ubuntu/debian/debian_copyright_2022

--- a/jammy/debian/docs
+++ b/jammy/debian/docs
@@ -1,1 +1,0 @@
-../../ubuntu/debian/docs

--- a/jammy/debian/libsdformat16-dev.install
+++ b/jammy/debian/libsdformat16-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libsdformat-dev.install

--- a/jammy/debian/libsdformat16.install
+++ b/jammy/debian/libsdformat16.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libsdformat.install

--- a/jammy/debian/python3-sdformat16.install
+++ b/jammy/debian/python3-sdformat16.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/python3-sdformat.install

--- a/jammy/debian/rules
+++ b/jammy/debian/rules
@@ -1,1 +1,0 @@
-../../ubuntu/debian/rules

--- a/jammy/debian/sdformat-doc.doc-base
+++ b/jammy/debian/sdformat-doc.doc-base
@@ -1,1 +1,0 @@
-../../ubuntu/debian/sdformat-doc.doc-base

--- a/jammy/debian/sdformat-doc.docs
+++ b/jammy/debian/sdformat-doc.docs
@@ -1,1 +1,0 @@
-../../ubuntu/debian/sdformat-doc.docs

--- a/jammy/debian/sdformat-doc.examples
+++ b/jammy/debian/sdformat-doc.examples
@@ -1,1 +1,0 @@
-../../ubuntu/debian/sdformat-doc.examples

--- a/jammy/debian/sdformat-doc.links
+++ b/jammy/debian/sdformat-doc.links
@@ -1,1 +1,0 @@
-../../ubuntu/debian/sdformat-doc.links

--- a/jammy/debian/sdformat14-doc.docs
+++ b/jammy/debian/sdformat14-doc.docs
@@ -1,1 +1,0 @@
-../../ubuntu/debian/sdformat-doc.docs

--- a/jammy/debian/sdformat16-sdf.install
+++ b/jammy/debian/sdformat16-sdf.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/sdformat-sdf.install

--- a/jammy/debian/source
+++ b/jammy/debian/source
@@ -1,1 +1,0 @@
-../../ubuntu/debian/source

--- a/jammy/debian/tests
+++ b/jammy/debian/tests
@@ -1,1 +1,0 @@
-../../ubuntu/debian/tests

--- a/jammy/debian/watch
+++ b/jammy/debian/watch
@@ -1,1 +1,0 @@
-../../ubuntu/debian/watch


### PR DESCRIPTION
The next Gazebo distribution will support only noble and newer versions of Ubuntu. This PR adds noble and removes older distributions.